### PR TITLE
Added a check to prevent WP CLI from breaking because of this plugin

### DIFF
--- a/functions/aqpb_functions.php
+++ b/functions/aqpb_functions.php
@@ -29,14 +29,16 @@ if(class_exists('AQ_Page_Builder')) {
 		}
 	}
 	
-	/** Get list of all blocks **/
-	function aq_get_blocks($template_id) {
+	/** Get list of all blocks * */
+	function aq_get_blocks( $template_id ) {
 		global $aq_page_builder;
-		$blocks = $aq_page_builder->get_blocks($template_id);
-		
-		return $blocks;
+		if ( is_a( $aq_page_builder, 'AQ_Page_Builder' ) ) {
+			$blocks = $aq_page_builder->get_blocks( $template_id );
+		} else {
+			return null;
+		}
 	}
-	
+
 	function array_htmlspecialchars(&$input)
 	{
 	    if (is_array($input))

--- a/functions/aqpb_functions.php
+++ b/functions/aqpb_functions.php
@@ -37,6 +37,7 @@ if(class_exists('AQ_Page_Builder')) {
 		} else {
 			return null;
 		}
+		return $blocks;
 	}
 
 	function array_htmlspecialchars(&$input)


### PR DESCRIPTION
Simply added a check to prevent WP CLI from breaking.
Global Variable `$aq_page_builder` is `NULL` when WP CLI is being used, so lets say you want to use WP CLI Command, lets say, 
`wp profile stage`
to check for bottlenecks in WordPress installs, it won't work.